### PR TITLE
Correct opened stdout split

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ NodeP4.prototype.opened = function (options, callback) {
     if (err) return callback(err);
 
     // process each file
-    result = stdout.trim().split('\n\n').reduce(function(memo, fileinfo) {
+    result = stdout.trim().split(/\r\n\r\n|\n\n/).reduce(function(memo, fileinfo) {
       // process each line of file info, transforming into a hash
       memo.push(processZtagOutput(fileinfo));
       return memo;


### PR DESCRIPTION
In my configuration I need to use '\r\n\r\n' to correctly split the groups of info.
When using '\n\n' I only get one element (the last of the groups).

I don't know if it's maybe Windows that gives those newlines.

I'm pretty sure this will work like before plus for me and others with similar setup as me.  :)