### PR TITLE
Adding more p4 options

### DIFF
--- a/p4options.js
+++ b/p4options.js
@@ -69,5 +69,37 @@ module.exports = {
     cmd: '-m',
     type: Number,
     category: 'mixed'
+  },
+  client: {
+    cmd: '-c',
+    type: String,
+    category: 'mixed'
+  },
+  long: {
+    cmd: '-l',
+    category: 'unary'
+  },
+  trunk: {
+    cmd: '-L',
+    category: 'unary'
+  },
+  status: {
+    cmd: '-s',
+    type: String,
+    category: 'mixed'
+  },
+  time: {
+    cmd: '-t',
+    category: 'unary'
+  },
+  user: {
+    cmd: '-u',
+    type: String,
+    category: 'mixed'
+  },
+  custom: {
+    cmd: ' ',
+    type: String,
+    category: 'mixed'
   }
 };


### PR DESCRIPTION
Adding options from http://www.perforce.com/perforce/r15.1/manuals/cmdref/p4_changes.html

The last, "custom" option allows adding any option which does not require a name, like this one for example "@2011/04/01,@2011/05/01":

	p4 changes @2011/04/01,@2011/05/01

Or "//depot/project/..."

	p4 changes -m 5 //depot/project/...

Option "cmd" has to be more than just an empty string in order for the query on line 23 of index.js to pass.

Ether that or we need to add  || ""===p4option.cmd to line 23 of index.js if "cmd" is an empty string.