### PR TITLE
Improved handling of p4 changes and p4 fstat.

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ NodeP4.prototype.changes = function (options, callback) {
     if (err) return callback(err);
 
     // process each change
-    result = stdout.trim().split(/\r\n\r\n|\n\n/).reduce(function(memo, changeinfo) {
+    result = stdout.trim().split(/\r\n\r\n|\n\n(?=\.\.\.)/).reduce(function(memo, changeinfo) {
       // process each line of change info, transforming into a hash
       memo.push(processZtagOutput(changeinfo));
       return memo;

--- a/index.js
+++ b/index.js
@@ -218,15 +218,39 @@ NodeP4.prototype.fstat = function (options, callback) {
     var result;
     if (err) return callback(err);
 
-    // process file info
-    result = processZtagOutput(stdout);
+    // process each file fstat info
+    result = stdout.trim().split(/\r\n\r\n|\n\n/).reduce(function(memo, fstatinfo) {
+      // process each line of file info, transforming into a hash
+      memo.push(processZtagOutput(fstatinfo));
+      return memo;
+    }, []);
 
     callback(null, result);
   });
 }
 
+NodeP4.prototype.changes = function (options, callback) {
+  if(typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  execP4('-ztag changes', options, function (err, stdout) {
+    var result;
+    if (err) return callback(err);
+
+    // process each change
+    result = stdout.trim().split(/\r\n\r\n|\n\n/).reduce(function(memo, changeinfo) {
+      // process each line of change info, transforming into a hash
+      memo.push(processZtagOutput(changeinfo));
+      return memo;
+    }, []);
+
+    callback(null, result);
+  });
+};
+
 var commonCommands = ['add', 'delete', 'edit', 'revert', 'sync',
-                      'diff', 'reconcile', 'changes', 'reopen', 'resolved',
+                      'diff', 'reconcile', 'reopen', 'resolved',
                       'shelve', 'unshelve', 'client', 'resolve', 'submit'];
 commonCommands.forEach(function (command) {
   NodeP4.prototype[command] = function (options, callback) {

--- a/index.js
+++ b/index.js
@@ -265,6 +265,26 @@ NodeP4.prototype.user = function (options, callback) {
   });
 };
 
+NodeP4.prototype.users = function (options, callback) {
+  if(typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  execP4('-ztag users', options, function (err, stdout) {
+    var result;
+    if (err) return callback(err);
+
+    // process each change
+    result = stdout.trim().split(/\r\n\r\n|\n\n(?=\.\.\.)/).reduce(function(memo, userinfo) {
+      // process each line of user info, transforming into a hash
+      memo.push(processZtagOutput(userinfo));
+      return memo;
+    }, []);
+
+    callback(null, result);
+  });
+};
+
 var commonCommands = ['add', 'delete', 'edit', 'revert', 'sync',
                       'diff', 'reconcile', 'reopen', 'resolved',
                       'shelve', 'unshelve', 'client', 'resolve', 'submit'];

--- a/index.js
+++ b/index.js
@@ -249,6 +249,22 @@ NodeP4.prototype.changes = function (options, callback) {
   });
 };
 
+NodeP4.prototype.user = function (options, callback) {
+  if(typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  execP4('-ztag user', options, function (err, stdout) {
+    var result;
+    if (err) return callback(err);
+
+    // process ztagged user information
+    result = processZtagOutput(stdout.trim());
+
+    callback(null, result);
+  });
+};
+
 var commonCommands = ['add', 'delete', 'edit', 'revert', 'sync',
                       'diff', 'reconcile', 'reopen', 'resolved',
                       'shelve', 'unshelve', 'client', 'resolve', 'submit'];

--- a/p4options.js
+++ b/p4options.js
@@ -41,12 +41,12 @@ module.exports = {
   },
   _delete: {
     cmd: '-d',
-    type: Number,
+    type: String,
     category: 'mixed'
   },
   _output: {
     cmd: '-o',
-    type: Number,
+    type: String,
     category: 'mixed'
   },
   force: {


### PR DESCRIPTION
Improved handling of p4 changes command, following the example set in the implementation of p4 opened.  It will return an array of objects.

Improved handling of p4 stat command, so it handles multiple files or wildcards which resolve to multiple files.  It also returns an array of objects now.

Added limited implementation for p4 user command - for use cases where a form editor does not come into play, such as p4 user -o, p4 user -d.

Added implementation of p4 users command, also modeled on the implementation of p4 opened.