### PR TITLE
When p4 changes query comes up empty, return [] instead of [{}]

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,8 +291,8 @@ NodeP4.prototype.users = function (options, callback) {
 };
 
 var commonCommands = ['add', 'delete', 'edit', 'revert', 'sync',
-  'diff', 'reconcile', 'reopen', 'resolved',
-  'shelve', 'unshelve', 'client', 'resolve', 'submit'];
+                      'diff', 'reconcile', 'reopen', 'resolved',
+                      'shelve', 'unshelve', 'client', 'resolve', 'submit'];
 commonCommands.forEach(function (command) {
   NodeP4.prototype[command] = function (options, callback) {
     execP4(command, options, callback);

--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ NodeP4.prototype.fstat = function (options, callback) {
 
     callback(null, result);
   });
-}
+};
 
 NodeP4.prototype.changes = function (options, callback) {
   if(typeof options === 'function') {
@@ -283,6 +283,31 @@ NodeP4.prototype.users = function (options, callback) {
     result = stdout.trim().split(/\r\n\r\n|\n\n(?=\.\.\.)/).reduce(function(memo, userinfo) {
       // process each line of user info, transforming into a hash
       memo.push(processZtagOutput(userinfo));
+      return memo;
+    }, []);
+
+    callback(null, result);
+  });
+};
+
+NodeP4.prototype.diff2 = function (options, callback) {
+  if(typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  execP4('-ztag diff2', options, function (err, stdout) { // TODO: Check that no more than two file arguments are provided
+    var result;
+    if (err) return callback(err);
+
+    // process each change
+    result = stdout.trim().split(/\r\n\r\n|\n\n(?=\.\.\.)/).reduce(function(memo, diff2info) {
+      // process each line of change info, transforming into a hash
+      var item = processZtagOutput(diff2info);
+
+      // If object representing change is not empty, push it onto array
+      if (Object.keys(item).length != 0)
+        memo.push(item);
+
       return memo;
     }, []);
 

--- a/index.js
+++ b/index.js
@@ -81,13 +81,13 @@ function execP4(p4cmd, options, callback) {
 function processZtagOutput(output) {
   return output.split('\n').reduce(function(memo, line) {
     var match, key, value;
-      match = ztagRegex.exec(line);
-      if(match) {
-        key = match[1];
-        value = match[2];
-        memo[key] = value;
-      }
-      return memo;
+    match = ztagRegex.exec(line);
+    if(match) {
+      key = match[1];
+      value = match[2];
+      memo[key] = value;
+    }
+    return memo;
   }, {});
 }
 
@@ -241,7 +241,12 @@ NodeP4.prototype.changes = function (options, callback) {
     // process each change
     result = stdout.trim().split(/\r\n\r\n|\n\n(?=\.\.\.)/).reduce(function(memo, changeinfo) {
       // process each line of change info, transforming into a hash
-      memo.push(processZtagOutput(changeinfo));
+      var item = processZtagOutput(changeinfo);
+
+      // If object representing change is not empty, push it onto array
+      if (Object.keys(item).length != 0)
+        memo.push(item);
+
       return memo;
     }, []);
 
@@ -286,8 +291,8 @@ NodeP4.prototype.users = function (options, callback) {
 };
 
 var commonCommands = ['add', 'delete', 'edit', 'revert', 'sync',
-                      'diff', 'reconcile', 'reopen', 'resolved',
-                      'shelve', 'unshelve', 'client', 'resolve', 'submit'];
+  'diff', 'reconcile', 'reopen', 'resolved',
+  'shelve', 'unshelve', 'client', 'resolve', 'submit'];
 commonCommands.forEach(function (command) {
   NodeP4.prototype[command] = function (options, callback) {
     execP4(command, options, callback);

--- a/p4options.js
+++ b/p4options.js
@@ -61,6 +61,10 @@ module.exports = {
     cmd: '-a',
     category: 'unary'
   },
+  quiet: {
+    cmd: '-q',
+    category: 'unary'
+  },
   files: {
     type: Array,
     category: 'mixed'

--- a/p4options.js
+++ b/p4options.js
@@ -65,6 +65,11 @@ module.exports = {
     cmd: '-q',
     category: 'unary'
   },
+  branch: {
+    cmd: '-b',
+    type: String,
+    category: 'mixed'
+  },
   files: {
     type: Array,
     category: 'mixed'


### PR DESCRIPTION
Previously, querying for changes where there were none would return an singleton array containing an empty object.  With this fix, an empty array is returned in such cases.
